### PR TITLE
Infinite test running script

### DIFF
--- a/infinite-run.sh
+++ b/infinite-run.sh
@@ -1,6 +1,7 @@
-#! /bin/bash
+#!/bin/bash
+set -e
 
- while true; do
+while true; do
 
  git rev-parse --is-inside-work-tree
  git config remote.origin.url git@github.com:novoda/droidcon-booth.git 


### PR DESCRIPTION
Adds a script to infinitely checkout the master branch of this repo and and run the connected tests

why? We can't be sure that we'll be able to set up our jenkins node on the conference connection, hence the back up script
