### PR TITLE
Fix build for tiles spiral test

### DIFF
--- a/mobile/src/androidTest/java/com/novoda/canvas/TilesSpiralActivityTest.java
+++ b/mobile/src/androidTest/java/com/novoda/canvas/TilesSpiralActivityTest.java
@@ -31,7 +31,7 @@ public class TilesSpiralActivityTest extends NovodaActivityTest {
 
     @Override
     public void startTestFor(Activity activity) {
-        ViewGroup parent = getParent(activity);
+        ViewGroup parent = getParent();
         availableRect = new Rect(parent.getLeft(), parent.getTop(), parent.getRight(), parent.getBottom());
         int baseColor = colorEditor.darken(randomColorFactory.getColor(), DARKER_BASE_COLOR_DARKEN_DELTA);
         int strokeColor = colorEditor.darken(baseColor, STROKE_COLOR_DARKEN_DELTA);


### PR DESCRIPTION
This PR fixes build for `TilesSpiralActivityTest.java` -- for some reason it's calling `getParent(activity)` but the actual `NovodaActivityTest#getParent` method takes no params.

![rick-and-morty-brothers](https://cloud.githubusercontent.com/assets/153802/10784745/b9809984-7d57-11e5-9831-5411c505478f.gif)
