### PR TITLE
Make the screen bright

### DIFF
--- a/mobile/src/main/java/com/novoda/canvas/NovodaActivity.java
+++ b/mobile/src/main/java/com/novoda/canvas/NovodaActivity.java
@@ -2,6 +2,7 @@ package com.novoda.canvas;
 
 import android.app.Activity;
 import android.os.Bundle;
+import android.view.WindowManager;
 
 import java.util.Random;
 
@@ -13,5 +14,7 @@ public class NovodaActivity extends Activity {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_novoda);
+
+        getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
     }
 }


### PR DESCRIPTION
Before: the screen dimmed after a few seconds (depending on device) after start of tests
After: the screen turns bright on start of tests and dims after end of tests
